### PR TITLE
ci(release): no release for deps-dev

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,7 @@
       "preset": "angular",
       "releaseRules": [
         {"type": "build", "release": "patch"},
+        {"type": "build", "scope": "deps-dev", "release": false},
         {"type": "chore", "release": "patch"},
         {"type": "chore", "scope": "release", "release": false},
         {"type": "ci", "release": false},


### PR DESCRIPTION
Updates to the dev dependencies should not trigger a new patch release since they won't affect the packaged application.