### PR TITLE
feat: allow custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
         with:
           argocd-exclude-paths: 'path/to/exclude,'
           argocd-extra-cli-args: '--grpc-web'
+          argocd-headers: 'Authorization: ${{ secrets.ARGO_CD_AUTHORIZATION_TOKEN }},SomeOtherHeader: some-value'
           argocd-server-fqdn: 'argocd.example.com'
           argocd-token: '${{ secrets.ARGOCD_TOKEN }}'
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/__tests__/argocd/AppCollection.test.ts
+++ b/__tests__/argocd/AppCollection.test.ts
@@ -33,6 +33,14 @@ test('getAppByName does not find a App', () => {
     expect(appCollection().getAppByName('non-existent-app-name')).toStrictEqual(undefined);
 });
 
+test('empty app collection', () => {
+    const appCollection = new AppCollection([]);
+    expect(appCollection.getAppByName('non-existent-app-name')).toStrictEqual(undefined);
+    expect(appCollection.filterByExcludedPath([])).toStrictEqual(appCollection);
+    expect(appCollection.filterByRepo('non-existent-repo')).toStrictEqual(appCollection);
+    expect(appCollection.filterByTargetRevision()).toStrictEqual(appCollection);
+});
+
 function appOne(): App {
     return {
         metadata: {

--- a/__tests__/argocd/ArgoCDServer.test.ts
+++ b/__tests__/argocd/ArgoCDServer.test.ts
@@ -109,7 +109,7 @@ describe('ArgoCDServer tests', function () {
         expect(mockedExecCommand).toHaveBeenCalledWith(
             `bin/argo app diff --local-repo-root=${process.cwd()} ${appOne().metadata.name} --local=${
                 appOne().spec.source?.path
-            } --exit-code=false --auth-token=fakeArgoCdToken --server=argocd.example `,
+            } --exit-code=false --auth-token=fakeArgoCdToken --server=argocd.example --header "Authorization: Bearer super-secret-bearer-token" --header "X-Example-Header: Some custom value"`,
         );
     });
 
@@ -128,7 +128,7 @@ describe('ArgoCDServer tests', function () {
         expect(mockedExecCommand).toHaveBeenCalledWith(
             `bin/argo app diff --local-repo-root=${process.cwd()} ${
                 appThree().metadata.name
-            } --revision=1.2.2 --exit-code=false --auth-token=fakeArgoCdToken --server=argocd.example `,
+            } --revision=1.2.2 --exit-code=false --auth-token=fakeArgoCdToken --server=argocd.example --header "Authorization: Bearer super-secret-bearer-token" --header "X-Example-Header: Some custom value"`,
         );
     });
 });
@@ -207,13 +207,17 @@ function argocdServer(): ArgoCDServer {
     const actionInput: ActionInput = {
         arch: 'linux',
         argocd: {
+            cliVersion: '1.0.0',
             excludePaths: [],
             extraCliArgs: '',
             fqdn: 'argocd.example',
+            headers: new Map<string, string>(Object.entries({
+                'Authorization': 'Bearer super-secret-bearer-token',
+                'X-Example-Header': 'Some custom value',
+            })),
             protocol: 'https',
             token: 'fakeArgoCdToken',
             uri: 'https://argocd.example',
-            cliVersion: '1.0.0',
         },
         githubToken: 'fakeGithubToken',
         timezone: 'America/Toronto',

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -3,40 +3,43 @@ import { expect, test } from '@jest/globals';
 import { execCommand, type ExecResult, scrubSecrets } from '../src/lib.js';
 
 test('scrubSecrets replaces auth-token with ***', () => {
+    const headers = new Map<string, string>();
     const fakeAuthToken = 'super-secret-auth-token';
     const input = '/bin/argocd --grpc-web  --server=https://argocd.exmaple/ --auth-token=';
     const appendedFlag = ' --appended-flag=server.com';
-    expect(scrubSecrets(input + fakeAuthToken + appendedFlag)).toBe(input + '***' + appendedFlag);
+    expect(scrubSecrets(input + fakeAuthToken + appendedFlag, headers)).toBe(input + '***' + appendedFlag);
 });
 
 test('scrubSecrets replaces double quoted authorization header value with ***', () => {
+    const headers = new Map<string, string>(Object.entries({
+        Authorization: 'Bearer super-secret-bearer-token',
+    }));
     const header = '--header "Authorization: Bearer super-secret-bearer-token"';
     const appendedFlag = '--appended-flag=server.com';
     const input = `/bin/argocd --grpc-web  --server=https://argocd.example/ ${header} ${appendedFlag}`;
-    expect(scrubSecrets(input)).toContain('--header "Authorization: ***"');
+    expect(scrubSecrets(input, headers)).toContain('--header "Authorization: ***"');
 });
 
 test('scrubSecrets replaces singled quoted authorization header value with ***', () => {
+    const headers = new Map<string, string>(Object.entries({
+        Authorization: 'Bearer super-secret-bearer-token',
+    }));
     const header = '--header \'Authorization: Bearer super-secret-bearer-token\'';
     const appendedFlag = '--appended-flag=server.com';
     const input = `/bin/argocd --grpc-web  --server=https://argocd.example/ ${header} ${appendedFlag}`;
-    expect(scrubSecrets(input)).toContain('--header \'Authorization: ***\'');
+    expect(scrubSecrets(input, headers)).toContain('--header \'Authorization: ***\'');
 });
 
 test('scrubSecrets should leave non-authorization headers alone', () => {
+    const headers = new Map<string, string>(Object.entries({
+        Authorization: 'Bearer super-secret-bearer-token',
+    }));
     const header = '--header "Authorization: Bearer super-secret-bearer-token"';
     const appendedFlags = '--appended-flag=server.com --header "Host: argocd.local"';
     const input = `/bin/argocd --grpc-web  --server=https://argocd.example/ ${header} ${appendedFlags}`;
-    const output = scrubSecrets(input);
+    const output = scrubSecrets(input, headers);
     expect(output).toContain('--header "Authorization: ***"');
     expect(output).toContain(appendedFlags);
-});
-
-test('scrubSecrets replaces authorization (lower case a) header value with ***', () => {
-    const header = '--header "authorization: Bearer super-secret-bearer-token"';
-    const appendedFlag = '--appended-flag=server.com';
-    const input = `/bin/argocd --grpc-web  --server=https://argocd.example/ ${header} ${appendedFlag}`;
-    expect(scrubSecrets(input)).toContain('--header "authorization: ***"');
 });
 
 test('execCommand returns ExecResult', async () => {

--- a/action.yml
+++ b/action.yml
@@ -2,33 +2,37 @@ name: 'ArgoCD Diff'
 description: 'Diffs all ArgoCD apps in the repo, and provides the diff as a PR comment'
 author: 'argocd-diff-action'
 inputs:
+  argocd-exclude-paths:
+    description: 'ArgoCD app paths to exclude in comma separated list'
+    default: ''
+    required: false
+  argocd-extra-cli-args:
+    description: 'Extra arguments to pass to the argocd CLI'
+    default: '--grpc-web'
+    required: false
+  argocd-headers:
+    description: 'A list of headers to pass to argocd'
+    default: ''
+    required: false
   argocd-server-fqdn:
-    description: ArgoCD server FQDN (i.e., without the protocol)
+    description: 'ArgoCD server FQDN (i.e., without the protocol)'
     required: true
   argocd-server-tls:
-    description: Use TLS to communicate with ArgoCD
+    description: 'Use TLS to communicate with ArgoCD'
     default: 'true'
     required: false
   argocd-token:
-    description: ArgoCD token for a local or project-scoped user https://argoproj.github.io/argo-cd/operator-manual/user-management/#local-usersaccounts-v15
+    description: 'ArgoCD token for a local or project-scoped user https://argoproj.github.io/argo-cd/operator-manual/user-management/#local-usersaccounts-v15'
     required: true
   argocd-version:
     description: '`argocd` command version to install. Defaults to the server version.'
     default: ''
     required: false
   github-token:
-    description: Github Token
+    description: 'Github Token'
     required: true
-  argocd-extra-cli-args:
-    description: Extra arguments to pass to the argocd CLI
-    default: --grpc-web
-    required: false
-  argocd-exclude-paths:
-    description: ArgoCD app paths to exclude in comma separated list
-    default: ''
-    required: false
   timezone:
-    description: Timezone string used for dates in the github comment.
+    description: 'Timezone string used for dates in the github comment.'
     default: 'America/Toronto'
     required: false
 runs:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import eslintImportPlugin from 'eslint-plugin-import';
 
 export default tseslint.config(
-    globalIgnores(['**/dist/', '**/lib/', '**/node_modules/']),
+    globalIgnores(['**/coverage/', '**/dist/', '**/lib/', '**/node_modules/']),
     eslint.configs.recommended,
     tseslint.configs.recommended,
     stylistic.configs.customize({

--- a/src/getActionInput.ts
+++ b/src/getActionInput.ts
@@ -1,18 +1,41 @@
 import * as core from '@actions/core';
+import assert from 'node:assert/strict';
 
 export interface ActionInput {
     arch: string;
     argocd: {
+        cliVersion: string;
         excludePaths: string[];
         extraCliArgs: string;
         fqdn: string;
+        headers: Map<string, string>;
         protocol: string;
         token: string;
         uri: string;
-        cliVersion: string;
     };
     githubToken: string;
     timezone: string;
+}
+
+function parseHeaders(input: string): Map<string, string> {
+    const headers = new Map<string, string>();
+
+    for (const item of input.split(',')) {
+        let [header, value] = item.split(':');
+
+        assert(header);
+        assert(value);
+
+        header = header.trim();
+        value = value.trim();
+
+        assert.match(header, /.+/);
+        assert.match(value, /.+/);
+
+        headers.set(header, value);
+    }
+
+    return headers;
 }
 
 export default function getActionInput(): ActionInput {
@@ -28,13 +51,14 @@ export default function getActionInput(): ActionInput {
     return {
         arch: process.env.ARCH || 'linux',
         argocd: {
+            cliVersion: core.getInput('argocd-version'),
             excludePaths: core.getInput('argocd-exclude-paths').split(','),
             extraCliArgs,
             fqdn,
+            headers: parseHeaders(core.getInput('argocd-headers')),
             protocol,
             token: core.getInput('argocd-token'),
             uri: `${protocol}://${fqdn}`,
-            cliVersion: core.getInput('argocd-version'),
         },
         githubToken: core.getInput('github-token'),
         timezone: core.getInput('timezone'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ _Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezon
 | ✅     | The app is synced in ArgoCD, and diffs you see are solely from this PR. |
 | ⚠️      | The app is out-of-sync in ArgoCD, and the diffs you see include those changes plus any from this PR. |
 | 🛑     | There was an error generating the ArgoCD diffs due to changes in this PR. |
-`);
+`, actionInput.argocd.headers);
 
     const commentsResponse = await octokit.rest.issues.listComments({
         issue_number: github.context.issue.number,


### PR DESCRIPTION
Allows the user to specify custom headers for use with both the CLI and the api requests.