### PR TITLE
fix: throw when api returns errors

### DIFF
--- a/__tests__/argocd/ArgoCDServer.test.ts
+++ b/__tests__/argocd/ArgoCDServer.test.ts
@@ -43,9 +43,20 @@ describe('ArgoCDServer tests', function () {
         expect(argocdServer().fqdn).toBe('argocd.example');
     });
 
+    test('ArgoCDServer throws on 401', async () => {
+        fetchMock.get('https://argocd.example/api/v1/applications', {status: 401, body: '{"error":"no session information","code":16,"message":"no session information"}'});
+
+        expect(argocdServer().getAppCollection()).rejects.toThrow();
+    });
+
+    test('ArgoCDServer throws on 500', async () => {
+        fetchMock.get('https://argocd.example/api/v1/applications', {status: 500, body: ''});
+
+        expect(argocdServer().getAppCollection()).rejects.toThrow();
+    });
+
     test('ArgoCDServer uses http when argocd-server-tls is false', async () => {
-        fetchMock.get('http://argocd.example/api/v1/applications?%257D', 200, '{}');
-        fetchMock.get('http://argocd.example/api/v1/applications', 200, '{}');
+        fetchMock.get('http://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' }});
 
         // mock response from fetch used in getServerVersion.
         fetchMock.anyOnce(
@@ -64,8 +75,7 @@ describe('ArgoCDServer tests', function () {
     });
 
     test('ArgoCDServer installArgoCDCommand defaults to server version & calls downloadTool', async () => {
-        fetchMock.get('https://argocd.example/api/v1/applications?%257D', 200, '{}');
-        fetchMock.get('https://argocd.example/api/v1/applications', 200, '{}');
+        fetchMock.get('https://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' }});
 
         // mock response from fetch used in getServerVersion.
         fetchMock.anyOnce(


### PR DESCRIPTION
This action should fail when the ArgoCD api returns errors.

fixes: #115