### PR TITLE
test: support ESM-only @actions deps and stricter @types/node in jest

### DIFF
--- a/__mocks__/@actions/core.js
+++ b/__mocks__/@actions/core.js
@@ -1,0 +1,19 @@
+// Manual mock for @actions/core.
+//
+// @actions/core v3+ is ESM-only (no CommonJS `require` export), and the jest
+// suite transpiles to CommonJS via ts-jest. Loading the real package would
+// fail to resolve under `require`. The action only uses @actions/core for
+// logging/inputs, none of which the tests assert on, so a no-op mock is
+// sufficient and keeps the ESM-only dependency chain out of the test runner.
+//
+// Jest applies manual mocks for node modules automatically (see
+// https://jestjs.io/docs/manual-mocks#mocking-node-modules), so no explicit
+// jest.mock('@actions/core') call is required.
+module.exports = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  warning: jest.fn(),
+  info: jest.fn(),
+  setFailed: jest.fn(),
+  getInput: jest.fn(),
+};

--- a/__mocks__/@actions/tool-cache.js
+++ b/__mocks__/@actions/tool-cache.js
@@ -1,0 +1,12 @@
+// Manual mock for @actions/tool-cache.
+//
+// @actions/tool-cache v3+ is ESM-only (no CommonJS `require` export), and the
+// jest suite transpiles to CommonJS via ts-jest. The tests already replace
+// downloadTool with a jest mock, so a no-op manual mock keeps the real
+// ESM-only package (and its dependency chain) out of the CommonJS test runner.
+//
+// Jest applies manual mocks for node modules automatically (see
+// https://jestjs.io/docs/manual-mocks#mocking-node-modules).
+module.exports = {
+  downloadTool: jest.fn(),
+};

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -14,10 +14,10 @@ export interface ExecResult {
 
 export async function execCommand(command: string, options: ExecOptions = {}): Promise<ExecResult> {
     return new Promise<ExecResult>((done, failed) => {
-        exec(command, options, (err: ExecException | null, stdout: string, stderr: string): void => {
+        exec(command, options, (err: ExecException | null, stdout: string | Buffer, stderr: string | Buffer): void => {
             const res: ExecResult = {
-                stdout,
-                stderr,
+                stdout: stdout.toString(),
+                stderr: stderr.toString(),
             };
             if (err) {
                 res.err = err;


### PR DESCRIPTION
## Why

Six open Dependabot PRs are major bumps that fail CI (or break tooling) for two reasons unrelated to the bumps themselves. This unblocks them on `main` so they pass after rebase.

### 1. `@actions/*` v3+ are ESM-only (unblocks #200, #199)
`@actions/core@3`, `@actions/exec@3`, `@actions/http-client@4`, `@actions/io@3`, and `@actions/tool-cache@4` dropped their CommonJS `require` export (`"type": "module"`). The jest suite transpiles to CommonJS via ts-jest, so `require('@actions/core')` fails to resolve when a suite loads `ArgoCDServer.ts`. The ncc bundle is unaffected (it compiles to ESM).

Fix: add manual mocks at `__mocks__/@actions/{core,tool-cache}.js`. Jest applies node-module manual mocks automatically. `@actions/core` is only used for logging (never asserted) and `@actions/tool-cache` is already mocked in the suite, so this keeps the ESM-only dependency chain out of the CommonJS test runner.

### 2. Stricter `@types/node` exec overloads (unblocks the #202 dev-deps group)
`@types/node@20.19.33` tightened `child_process.exec`'s overloads; `execCommand`'s `string` callback params no longer type-check (ts-jest type-checks at load since `isolatedModules` is off).

Fix: widen the callback params to `string | Buffer` and `.toString()` them. Behavior-preserving (`.toString()` on a string is identity).

## Verification
- `pnpm run test`: all suites pass on CI (the lone local `badBinary` failure is a `/bin/sh`→bash vs dash artifact, green on CI).
- `pnpm run build`: ncc bundles cleanly against the bumped majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)