### PR TITLE
build(deps-dev): upgrade pnpm to 11.2.2

### DIFF
--- a/__mocks__/@actions/core.js
+++ b/__mocks__/@actions/core.js
@@ -10,10 +10,10 @@
 // https://jestjs.io/docs/manual-mocks#mocking-node-modules), so no explicit
 // jest.mock('@actions/core') call is required.
 module.exports = {
-  debug: jest.fn(),
-  error: jest.fn(),
-  warning: jest.fn(),
-  info: jest.fn(),
-  setFailed: jest.fn(),
-  getInput: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+    setFailed: jest.fn(),
+    getInput: jest.fn(),
 };

--- a/__mocks__/@actions/tool-cache.js
+++ b/__mocks__/@actions/tool-cache.js
@@ -8,5 +8,5 @@
 // Jest applies manual mocks for node modules automatically (see
 // https://jestjs.io/docs/manual-mocks#mocking-node-modules).
 module.exports = {
-  downloadTool: jest.fn(),
+    downloadTool: jest.fn(),
 };

--- a/__tests__/argocd/AppCollection.test.ts
+++ b/__tests__/argocd/AppCollection.test.ts
@@ -1,7 +1,7 @@
-import {expect, test} from '@jest/globals';
+import { expect, test } from '@jest/globals';
 
-import {type App} from '../../src/argocd/App.js';
-import {AppCollection} from '../../src/argocd/AppCollection.js';
+import { type App } from '../../src/argocd/App.js';
+import { AppCollection } from '../../src/argocd/AppCollection.js';
 
 test('filterByRepo removes apps from other repos', () => {
     expect(appCollection().filterByRepo('argocd-diff-action/app-one')).toStrictEqual(

--- a/__tests__/argocd/ArgoCDServer.test.ts
+++ b/__tests__/argocd/ArgoCDServer.test.ts
@@ -44,19 +44,19 @@ describe('ArgoCDServer tests', function () {
     });
 
     test('ArgoCDServer throws on 401', async () => {
-        fetchMock.get('https://argocd.example/api/v1/applications', {status: 401, body: '{"error":"no session information","code":16,"message":"no session information"}'});
+        fetchMock.get('https://argocd.example/api/v1/applications', { status: 401, body: '{"error":"no session information","code":16,"message":"no session information"}' });
 
         expect(argocdServer().getAppCollection()).rejects.toThrow();
     });
 
     test('ArgoCDServer throws on 500', async () => {
-        fetchMock.get('https://argocd.example/api/v1/applications', {status: 500, body: ''});
+        fetchMock.get('https://argocd.example/api/v1/applications', { status: 500, body: '' });
 
         expect(argocdServer().getAppCollection()).rejects.toThrow();
     });
 
     test('ArgoCDServer uses http when argocd-server-tls is false', async () => {
-        fetchMock.get('http://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' }});
+        fetchMock.get('http://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' } });
 
         // mock response from fetch used in getServerVersion.
         fetchMock.anyOnce(
@@ -66,7 +66,7 @@ describe('ArgoCDServer tests', function () {
         );
         mockedDownloadTool.mockReturnValueOnce(Promise.resolve('/path/to/tool'));
 
-        await argocdServer({ protocol: 'http', uri: 'http://argocd.example', fqdn: 'argocd.example'}).installArgoCDCommand('');
+        await argocdServer({ protocol: 'http', uri: 'http://argocd.example', fqdn: 'argocd.example' }).installArgoCDCommand('');
 
         expect(mockedDownloadTool).toHaveBeenCalledWith(
             'https://github.com/argoproj/argo-cd/releases/download/v2.4.0/argocd-linux-amd64',
@@ -75,7 +75,7 @@ describe('ArgoCDServer tests', function () {
     });
 
     test('ArgoCDServer installArgoCDCommand defaults to server version & calls downloadTool', async () => {
-        fetchMock.get('https://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' }});
+        fetchMock.get('https://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' } });
 
         // mock response from fetch used in getServerVersion.
         fetchMock.anyOnce(

--- a/__tests__/parseHeaders.test.ts
+++ b/__tests__/parseHeaders.test.ts
@@ -1,11 +1,11 @@
-import {expect, test} from '@jest/globals';
-import {parseHeaders} from '../src/getActionInput.js';
+import { expect, test } from '@jest/globals';
+import { parseHeaders } from '../src/getActionInput.js';
 
 test('parseHeaders with a single header', () => {
     const headers = parseHeaders('Authorization: Bearer super-secret-bearer-token');
     expect(headers).toStrictEqual(new Map<string, string>(Object.entries({
-        'Authorization': 'Bearer super-secret-bearer-token',
-    })))
+        Authorization: 'Bearer super-secret-bearer-token',
+    })));
 });
 
 test('parseHeaders with multiple headers', () => {
@@ -13,12 +13,12 @@ test('parseHeaders with multiple headers', () => {
     expect(headers).toStrictEqual(new Map<string, string>(Object.entries({
         'Authorization': 'Bearer super-secret-bearer-token',
         'X-Example': 'example-value',
-    })))
+    })));
 });
 
 test('parseHeaders with a bad header', () => {
     expect(() => {
-        parseHeaders('Authorization')
+        parseHeaders('Authorization');
     }).toThrow();
 });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,7 +52,7 @@ export default tseslint.config(
                 },
             ],
 
-            '@stylistic/func-call-spacing': ['error', 'never'],
+            '@stylistic/function-call-spacing': ['error', 'never'],
             '@typescript-eslint/no-array-constructor': 'error',
             '@typescript-eslint/no-empty-interface': 'error',
             '@typescript-eslint/no-explicit-any': 'error',
@@ -76,5 +76,13 @@ export default tseslint.config(
             'github/array-foreach': 'off',
             '@stylistic/type-annotation-spacing': 'error',
             '@typescript-eslint/unbound-method': 'error',
+        },
+    },
+    {
+        files: ['__tests__/**', '__mocks__/**'],
+        languageOptions: {
+            globals: {
+                ...globals.jest,
+            },
         },
     });

--- a/package.json
+++ b/package.json
@@ -62,12 +62,5 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.59.4"
   },
-  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "pre-commit",
-      "spawn-sync",
-      "unrs-resolver"
-    ]
-  }
+  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  pre-commit: true
+  spawn-sync: true
+  unrs-resolver: true

--- a/src/argocd/ArgoCDServer.ts
+++ b/src/argocd/ArgoCDServer.ts
@@ -1,14 +1,14 @@
-import {chmodSync} from 'fs';
+import { chmodSync } from 'fs';
 import * as core from '@actions/core';
-import {downloadTool} from '@actions/tool-cache';
+import { downloadTool } from '@actions/tool-cache';
 
-import {type App} from './App.js';
-import {AppCollection} from './AppCollection.js';
-import {type AppTargetRevision} from './AppTargetRevision.js';
-import {type Diff} from '../Diff.js';
-import {type ExecResult, execCommand, scrubSecrets} from '../lib.js';
-import {ActionInput} from '../getActionInput.js';
-import {URL} from "node:url";
+import { type App } from './App.js';
+import { AppCollection } from './AppCollection.js';
+import { type AppTargetRevision } from './AppTargetRevision.js';
+import { type Diff } from '../Diff.js';
+import { type ExecResult, execCommand, scrubSecrets } from '../lib.js';
+import { ActionInput } from '../getActionInput.js';
+import { URL } from 'node:url';
 
 export class ArgoCDServer {
     binaryPath = 'bin/argo';
@@ -59,7 +59,7 @@ export class ArgoCDServer {
         if (app.spec.source?.path === undefined) {
             core.error(`Cannot diff ${app.metadata.name}, no source.path`);
 
-            return {app, diff: ''} as Diff;
+            return { app, diff: '' };
         }
 
         return this.getAppDiff(app, [`--local=${app.spec.source.path}`]);
@@ -77,12 +77,13 @@ export class ArgoCDServer {
             );
             core.debug(`stdout: ${res.stdout}`);
             core.debug(`stderr: ${res.stderr}`);
-            return {app, diff: res.stdout} as Diff;
-        } catch (e) {
+            return { app, diff: res.stdout };
+        }
+        catch (e) {
             res = e as ExecResult;
             core.error('Unexpected error when fetching app diff:');
             core.error(`${res.err}`);
-            return {app, diff: '', error: res} as Diff;
+            return { app, diff: '', error: res };
         }
     }
 
@@ -90,7 +91,7 @@ export class ArgoCDServer {
     async api(endpoint: string, params: { [key: string]: string } = {}, method = 'GET'): Promise<any> {
         const url = new URL(`${this.uri}/api/${endpoint}`);
 
-        for (let paramsKey in params) {
+        for (const paramsKey in params) {
             if (params[paramsKey]) {
                 url.searchParams.append(paramsKey, params[paramsKey]);
             }
@@ -101,6 +102,7 @@ export class ArgoCDServer {
         // response.json() returns `any`.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let responseText: any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let responseJson: any;
 
         try {
@@ -120,7 +122,8 @@ export class ArgoCDServer {
             }
 
             responseJson = JSON.parse(responseText);
-        } catch (err) {
+        }
+        catch (err) {
             if (err instanceof Error) {
                 core.error(`Failed to fetch ${endpoint} from ${this.uri}.`);
                 core.error(`Response Text: ${responseText}`);
@@ -170,7 +173,8 @@ export class ArgoCDServer {
                 appCollectionDiffPromises.push(
                     this.getAppRevisionDiff(app, appTargetRevision.targetRevision),
                 );
-            } else {
+            }
+            else {
                 core.warning(
                     `Could not find Application '${appTargetRevision.appName}' in AppCollection for revision diffs.`,
                 );
@@ -191,10 +195,12 @@ export class ArgoCDServer {
             if (appDiff.error) {
                 core.setFailed(`ArgoCD diff failed for Application '${appDiff.app.metadata.name}'`);
                 diffs.push(appDiff); // Surface the error to the PR comment.
-            } else if (appDiff.diff != '') {
+            }
+            else if (appDiff.diff != '') {
                 core.info(`Found diff for Application '${appDiff.app.metadata.name}'.`);
                 diffs.push(appDiff);
-            } else {
+            }
+            else {
                 core.debug(`No diff found for Application '${appDiff.app.metadata.name}'.`);
             }
         });

--- a/src/getActionInput.ts
+++ b/src/getActionInput.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import assert from 'node:assert/strict';
 
 export interface ActionInput {
     arch: string;
@@ -26,7 +25,7 @@ export function parseHeaders(input: string): Map<string, string> {
             continue;
         }
 
-        let [header, value] = item.split(':').map(s => s.trim());
+        const [header, value] = item.split(':').map(s => s.trim());
 
         if (!header || header === '') {
             throw new Error(`Header name cannot be empty: ${item}`);


### PR DESCRIPTION
## Summary

- **Upgrade pnpm 10.6.5 → 11.2.2.** pnpm 11 no longer reads the `pnpm` field in `package.json` and removed `onlyBuiltDependencies`, so the build allowlist (`pre-commit`, `spawn-sync`, `unrs-resolver`) moves to an `allowBuilds` map in a new `pnpm-workspace.yaml`. Without this, those build scripts are silently skipped.
- **Repair eslint config.** `@stylistic` v5 renamed `func-call-spacing` → `function-call-spacing`, which broke config loading entirely — so the linter had never actually run, hiding latent violations. Renames the rule, adds `jest` globals for `__tests__`/`__mocks__`, drops an unused import, covers a second `any` with `eslint-disable`, and applies `lint:fix` formatting.

## Notes

- pnpm 11's new default 24h `minimumReleaseAge` is **kept** (deliberate). Frozen installs can transiently fail for up to 24h after a dependency bump until the new package ages out — relevant given dependabot auto-merge.
- The lockfile is unchanged (still `lockfileVersion 9.0`); a regeneration is a no-op and contains no <24h-old packages.
- `dist/` is not rebuilt here — it's regenerated by the release workflow. A local build produced a byte-identical bundle.
- One pre-existing test failure (`execCommand returns an err on failure` in `lib.test.ts`) is unrelated to this change and left untouched.

## Test plan

- [x] `pnpm i --frozen-lockfile` passes under pnpm 11
- [x] `pnpm run lint` exits clean
- [x] `pnpm run build` succeeds, `dist/index.js` byte-identical
- [x] `pnpm run test` — 27 pass (1 pre-existing, unrelated failure)