### PR TITLE
fix: use dynamic timezone abbreviation in PR comment timestamp

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,7 @@ ${diff}
 `;
 
     const output = scrubSecrets(`${header}
-_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone })} PT_
+_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone, timeZoneName: 'short' })}_
   ${diffOutput.join('\n')}
 
 | Legend | Status |


### PR DESCRIPTION
## Problem

Fixes #187. The PR comment timestamp formats the time using the configured `timezone` input but appends a hardcoded `PT` label:

```ts
_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone })} PT_
```

The time shifts with the timezone; the `PT` label never does. Since the `timezone` input defaults to `America/Toronto` (Eastern), the label is already wrong out of the box.

## Fix

Drop the literal and let `Intl` emit the matching abbreviation via the `timeZoneName: 'short'` option.

| timezone | before | after |
|---|---|---|
| `America/Toronto` (default) | `… p.m. PT` ❌ | `… p.m. EDT` ✅ |
| `America/Los_Angeles` | `… p.m. PT` | `… p.m. PDT` |
| `Europe/Berlin` | `… p.m. PT` ❌ | `… p.m. GMT+2` |
| `UTC` | `… p.m. PT` ❌ | `… p.m. UTC` |

For IANA zones without a common abbreviation, `Intl` falls back to a `GMT±N` offset — still correct.

## Notes

- `dist/index.js` is intentionally **not** included; `semantic-release` regenerates `dist/**` on release.
- `pnpm run build` and `pnpm run lint` pass. No tests assert on this string.