### PR TITLE
feat: split large diffs across multiple PR comments

### DIFF
--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from '@jest/globals';
+
+import { type App } from '../src/argocd/App.js';
+import { type Diff } from '../src/Diff.js';
+import { buildCommentBodies, commentMarkerPrefix, MAX_COMMENT_LENGTH } from '../src/comment.js';
+
+const fqdn = 'argocd.example.com';
+
+function options(diffs: Diff[]): Parameters<typeof buildCommentBodies>[0] {
+    return {
+        diffs,
+        fqdn,
+        uri: `https://${fqdn}`,
+        title: `ArgoCD Diff ${fqdn} for commit [\`abc1234\`](https://example.com)`,
+        updatedAt: '_Updated at 2026-05-23_',
+        headers: new Map<string, string>(),
+    };
+}
+
+function bodyAt(bodies: string[], index: number): string {
+    const body = bodies.at(index);
+    if (body === undefined) {
+        throw new Error(`expected a comment body at index ${index}`);
+    }
+    return body;
+}
+
+function app(name: string, path = `deploy/${name}`): App {
+    return {
+        metadata: { name },
+        spec: { source: { repoURL: `https://github.com/org/${name}`, path, targetRevision: 'HEAD' } },
+        status: { sync: { status: 'Synced' } },
+    };
+}
+
+function diffOfLength(length: number): string {
+    let out = '===== apps/Deployment default/app ======\n';
+    while (out.length < length) {
+        out += '> spec.replicas: 1\n';
+    }
+    return out.slice(0, length);
+}
+
+function manyResources(count: number): string {
+    let out = '';
+    for (let i = 0; i < count; i++) {
+        out += `===== apps/Deployment default/app-${i} ======\n`;
+        out += '> spec.replicas: 1\n'.repeat(20);
+    }
+    return out;
+}
+
+test('small diffs render to a single comment with the legend and no part suffix', () => {
+    const bodies = buildCommentBodies(options([
+        { app: app('app-one'), diff: '===== apps/Deployment default/app-one ======\n> spec.replicas: 1' },
+        { app: app('app-two'), diff: '===== apps/Deployment default/app-two ======\n> spec.replicas: 2' },
+    ]));
+
+    expect(bodies).toHaveLength(1);
+    const body = bodyAt(bodies, 0);
+    expect(body).toContain(commentMarkerPrefix(fqdn));
+    expect(body).toContain('app-one');
+    expect(body).toContain('app-two');
+    expect(body).toContain('| Legend | Status |');
+    expect(body).not.toContain('(part');
+    expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH);
+});
+
+test('no diffs and no prior comment still yields one updatable body', () => {
+    const bodies = buildCommentBodies(options([]));
+
+    expect(bodies).toHaveLength(1);
+    expect(bodyAt(bodies, 0)).toContain('| Legend | Status |');
+});
+
+test('diffs exceeding one comment split across multiple comments under the limit', () => {
+    const diffs: Diff[] = Array.from({ length: 4 }, (_, i) => ({
+        app: app(`app-${i}`),
+        diff: diffOfLength(30000),
+    }));
+
+    const bodies = buildCommentBodies(options(diffs));
+
+    expect(bodies.length).toBeGreaterThan(1);
+    bodies.forEach((body, index) => {
+        expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH);
+        expect(body).toContain(`part ${index + 1}/${bodies.length}`);
+        expect(body).toContain(`(part ${index + 1}/${bodies.length})`);
+    });
+    // Legend only on the final comment.
+    expect(bodyAt(bodies, -1)).toContain('| Legend | Status |');
+    expect(bodyAt(bodies, 0)).not.toContain('| Legend | Status |');
+    expect(bodies.every(body => !body.includes('Diff truncated'))).toBe(true);
+});
+
+test('a single oversized app diff is truncated by whole resources with a notice', () => {
+    const bodies = buildCommentBodies(options([
+        { app: app('huge-app'), diff: manyResources(200) },
+    ]));
+
+    expect(bodies).toHaveLength(1);
+    const body = bodyAt(bodies, 0);
+    expect(body.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH);
+    expect(body).toContain('Diff truncated');
+    expect(body).toMatch(/showing \d+\/200 resources/);
+    expect(body).toContain('argocd app diff huge-app --local=deploy/huge-app');
+});
+
+test('secrets in the diff are scrubbed from the rendered body', () => {
+    const headers = new Map<string, string>([['Authorization', 'Bearer super-secret']]);
+    const bodies = buildCommentBodies({
+        ...options([{ app: app('app-one'), diff: 'header --header "Authorization: Bearer super-secret"' }]),
+        headers,
+    });
+
+    const body = bodyAt(bodies, 0);
+    expect(body).toContain('Authorization: ***');
+    expect(body).not.toContain('Bearer super-secret');
+});

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,0 +1,183 @@
+// comment.ts - renders ArgoCD diffs into PR comment bodies that respect
+// GitHub's per-comment size limit by splitting across multiple comments and,
+// as a last resort, truncating a single oversized app diff by whole resources.
+import { type App } from './argocd/App.js';
+import { type Diff } from './Diff.js';
+import { scrubSecrets } from './lib.js';
+
+// GitHub rejects issue comment bodies longer than 65,536 characters. Stay
+// under it with margin for the join newlines and any rendering slack.
+export const MAX_COMMENT_LENGTH = 65000;
+
+// Reserved space for the truncation notice, which is added only when an app's
+// diff is truncated and so is not counted in the untruncated section length.
+const NOTICE_ALLOWANCE = 400;
+
+// ArgoCD separates each changed resource in a diff with a header line like
+// `===== apps/Deployment my-namespace/my-app ======`.
+const RESOURCE_BOUNDARY = /^={5,} .+ ={5,}$/m;
+const RESOURCE_SPLIT = /(?=^={5,} .+ ={5,}$)/m;
+
+const LEGEND = `| Legend | Status |
+| :---:  | :---   |
+| ✅     | The app is synced in ArgoCD, and diffs you see are solely from this PR. |
+| ⚠️      | The app is out-of-sync in ArgoCD, and the diffs you see include those changes plus any from this PR. |
+| 🛑     | There was an error generating the ArgoCD diffs due to changes in this PR. |`;
+
+export interface BuildCommentOptions {
+    diffs: Diff[];
+    fqdn: string;
+    uri: string;
+    title: string;
+    updatedAt: string;
+    headers: Map<string, string>;
+}
+
+export function commentMarkerPrefix(fqdn: string): string {
+    return `<!-- argocd-diff-action ${fqdn} `;
+}
+
+function commentMarker(fqdn: string, part: number, total: number): string {
+    return `${commentMarkerPrefix(fqdn)}part ${part}/${total} -->`;
+}
+
+// Renders the diffs into one or more comment bodies, each within
+// MAX_COMMENT_LENGTH. Always returns at least one body so an existing comment
+// can be updated to reflect that there are no diffs this round.
+export function buildCommentBodies(options: BuildCommentOptions): string[] {
+    const { diffs, fqdn, uri, title, updatedAt, headers } = options;
+
+    // Reserve worst-case frame overhead (largest part indicator + legend on
+    // every page) so each section is guaranteed to fit once framed.
+    const sampleFrame = `${commentMarker(fqdn, 99, 99)}
+## ${title} (part 99/99)
+${updatedAt}
+
+${LEGEND}`;
+    const sectionBudget = MAX_COMMENT_LENGTH - sampleFrame.length;
+
+    const sections = diffs.map(diff => renderAppSection(diff, uri, sectionBudget));
+
+    const pages: string[][] = [];
+    let current: string[] = [];
+    let currentLength = 0;
+    for (const section of sections) {
+        if (current.length > 0 && currentLength + section.length + 1 > sectionBudget) {
+            pages.push(current);
+            current = [];
+            currentLength = 0;
+        }
+        current.push(section);
+        currentLength += section.length + 1;
+    }
+    if (current.length > 0 || pages.length === 0) {
+        pages.push(current);
+    }
+
+    const total = pages.length;
+    return pages.map((pageSections, index) => {
+        const part = index + 1;
+        const partSuffix = total > 1 ? ` (part ${part}/${total})` : '';
+        const body = `${commentMarker(fqdn, part, total)}
+## ${title}${partSuffix}
+${updatedAt}
+${pageSections.join('\n')}
+
+${part === total ? LEGEND : ''}`;
+        return scrubSecrets(body, headers);
+    });
+}
+
+function renderAppSection(diff: Diff, uri: string, budget: number): string {
+    const header = renderAppHeader(diff, uri);
+    if (!diff.diff) {
+        return `${header}
+---
+`;
+    }
+
+    const fullSection = `${header}
+${renderDiffBlock(diff.diff)}
+---
+`;
+    if (fullSection.length <= budget) {
+        return fullSection;
+    }
+
+    const nonDiffLength = fullSection.length - diff.diff.length;
+    const diffBudget = Math.max(0, budget - nonDiffLength - NOTICE_ALLOWANCE);
+    const { text, shown, total } = truncateDiff(diff.diff, diffBudget);
+    return `${header}
+${truncationNotice(diff.app, shown, total)}
+${renderDiffBlock(text)}
+---
+`;
+}
+
+function renderAppHeader(diff: Diff, uri: string): string {
+    const { app, error } = diff;
+    const syncStatus = app.status.sync.status === 'Synced' ? 'Synced ✅' : 'Out of Sync ⚠️ ';
+    const errorBlock = error
+        ? `
+**\`stderr:\`**
+\`\`\`
+${error.stderr}
+\`\`\`
+
+**\`command:\`**
+\`\`\`json
+${JSON.stringify(error.err)}
+\`\`\`
+`
+        : '';
+    return `
+App: [\`${app.metadata.name}\`](${uri}/applications/${app.metadata.name})
+YAML generation: ${error ? ' Error 🛑' : 'Success 🟢'}
+App sync status: ${syncStatus}
+${errorBlock}`;
+}
+
+function renderDiffBlock(diff: string): string {
+    return `<details>
+
+\`\`\`diff
+${diff}
+\`\`\`
+
+</details>`;
+}
+
+// Keeps whole resources from the diff up to the budget. Falls back to a hard
+// character cut only when even the first resource exceeds the budget, so the
+// comment always shows some content rather than an empty block.
+function truncateDiff(diff: string, budget: number): { text: string; shown: number; total: number } {
+    const chunks = diff.split(RESOURCE_SPLIT);
+    const total = chunks.filter(chunk => RESOURCE_BOUNDARY.test(chunk)).length;
+
+    let text = '';
+    let shown = 0;
+    for (const chunk of chunks) {
+        if (text.length + chunk.length > budget) {
+            break;
+        }
+        text += chunk;
+        if (RESOURCE_BOUNDARY.test(chunk)) {
+            shown += 1;
+        }
+    }
+
+    if (text === '') {
+        text = diff.slice(0, Math.max(0, budget));
+    }
+
+    return { text: text.trimEnd(), shown, total };
+}
+
+function truncationNotice(app: App, shown: number, total: number): string {
+    const path = app.spec.source?.path;
+    const command = path
+        ? `argocd app diff ${app.metadata.name} --local=${path}`
+        : `argocd app diff ${app.metadata.name}`;
+    return `> ⚠️ Diff truncated (showing ${shown}/${total} resources). Run locally to see the full diff:
+> \`${command}\``;
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -12,9 +12,14 @@ export interface ExecResult {
     stderr: string;
 }
 
+// Large `argocd app diff` output overflows Node's default 1 MB stdout buffer
+// and crashes with ERR_CHILD_PROCESS_STDIO_MAXBUFFER before any diff is posted.
+const MAX_EXEC_BUFFER = 50 * 1024 * 1024;
+
 export async function execCommand(command: string, options: ExecOptions = {}): Promise<ExecResult> {
+    const execOptions: ExecOptions = { maxBuffer: MAX_EXEC_BUFFER, ...options };
     return new Promise<ExecResult>((done, failed) => {
-        exec(command, options, (err: ExecException | null, stdout: string | Buffer, stderr: string | Buffer): void => {
+        exec(command, execOptions, (err: ExecException | null, stdout: string | Buffer, stderr: string | Buffer): void => {
             const res: ExecResult = {
                 stdout: stdout.toString(),
                 stderr: stderr.toString(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github';
 
 import { computeDiffs } from './computeDiffs.js';
 import { type Diff } from './Diff.js';
-import { scrubSecrets } from './lib.js';
+import { buildCommentBodies, commentMarkerPrefix } from './comment.js';
 import getActionInput, { ActionInput } from './getActionInput.js';
 
 run().catch((e) => {
@@ -28,87 +28,50 @@ async function postDiffComment(diffs: Diff[], actionInput: ActionInput): Promise
     const commitLink = `https://github.com/${owner}/${repo}/pull/${github.context.issue.number}/commits/${sha}`;
     const shortCommitSha = String(sha).substring(0, 7);
 
-    const diffOutput = diffs.map(
-        ({ app, diff, error }) => `
-App: [\`${app.metadata.name}\`](${actionInput.argocd.uri}/applications/${app.metadata.name})
-YAML generation: ${error ? ' Error 🛑' : 'Success 🟢'}
-App sync status: ${app.status.sync.status === 'Synced' ? 'Synced ✅' : 'Out of Sync ⚠️ '}
-${
-    error
-        ? `
-**\`stderr:\`**
-\`\`\`
-${error.stderr}
-\`\`\`
+    const bodies = buildCommentBodies({
+        diffs,
+        fqdn: actionInput.argocd.fqdn,
+        uri: actionInput.argocd.uri,
+        title: `ArgoCD Diff ${actionInput.argocd.fqdn} for commit [\`${shortCommitSha}\`](${commitLink})`,
+        updatedAt: `_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone, timeZoneName: 'short' })}_`,
+        headers: actionInput.argocd.headers,
+    });
 
-**\`command:\`**
-\`\`\`json
-${JSON.stringify(error.err)}
-\`\`\`
-`
-        : ''
-}
-
-${
-    diff
-        ? `
-<details>
-
-\`\`\`diff
-${diff}
-\`\`\`
-
-</details>
-`
-        : ''
-}
----
-`,
-    );
-
-    // Use a unique value at the beginning of each comment so we can find the correct comment for the argocd server FQDN
-    const headerPrefix = `<!-- argocd-diff-action ${actionInput.argocd.fqdn} -->`;
-    const header = `${headerPrefix}
-## ArgoCD Diff ${actionInput.argocd.fqdn} for commit [\`${shortCommitSha}\`](${commitLink})
-`;
-
-    const output = scrubSecrets(`${header}
-_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone })} PT_
-  ${diffOutput.join('\n')}
-
-| Legend | Status |
-| :---:  | :---   |
-| ✅     | The app is synced in ArgoCD, and diffs you see are solely from this PR. |
-| ⚠️      | The app is out-of-sync in ArgoCD, and the diffs you see include those changes plus any from this PR. |
-| 🛑     | There was an error generating the ArgoCD diffs due to changes in this PR. |
-`, actionInput.argocd.headers);
-
+    // Each comment is keyed by a hidden marker carrying the ArgoCD FQDN so that
+    // re-runs find and update their own comments instead of stacking new ones.
+    const markerPrefix = commentMarkerPrefix(actionInput.argocd.fqdn);
     const commentsResponse = await octokit.rest.issues.listComments({
         issue_number: github.context.issue.number,
         owner,
         repo,
     });
+    const existingComments = commentsResponse.data
+        .filter(comment => comment.body?.includes(markerPrefix) ?? false)
+        .sort((a, b) => a.id - b.id);
 
-    const existingComment = commentsResponse.data.find(
-        d => d.body?.includes(headerPrefix) ?? false,
-    );
-
-    // Existing comments should be updated even if there are no changes this round in order to indicate that
-    if (existingComment) {
-        await octokit.rest.issues.updateComment({
-            owner,
-            repo,
-            comment_id: existingComment.id,
-            body: output,
-        });
-    // Only post a new comment when there are changes
+    // Nothing to report and nothing posted before: stay silent.
+    if (diffs.length === 0 && existingComments.length === 0) {
+        return;
     }
-    else if (diffs.length) {
-        await octokit.rest.issues.createComment({
-            issue_number: github.context.issue.number,
-            owner,
-            repo,
-            body: output,
-        });
+
+    // Reconcile the rendered pages against existing comments: update in place,
+    // create any missing pages, and delete leftovers from a larger prior run.
+    for (let i = 0; i < bodies.length; i++) {
+        const body = bodies[i] ?? '';
+        const existing = existingComments[i];
+        if (existing) {
+            await octokit.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+        }
+        else {
+            await octokit.rest.issues.createComment({
+                issue_number: github.context.issue.number,
+                owner,
+                repo,
+                body,
+            });
+        }
+    }
+    for (const comment of existingComments.slice(bodies.length)) {
+        await octokit.rest.issues.deleteComment({ owner, repo, comment_id: comment.id });
     }
 }


### PR DESCRIPTION
## Summary

Fixes #193: large ArgoCD diffs broke the action in two distinct ways, addressed here.

1. **`exec` buffer overflow.** A large `argocd app diff` overflows Node's default 1 MB stdout buffer and crashes with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` *before any comment is built*. `execCommand` now defaults `maxBuffer` to 50 MB.
2. **GitHub comment size limit.** The whole diff was concatenated into a single comment; over GitHub's 65,536-character limit the `createComment`/`updateComment` call failed with `Body is too long`. Diffs are now rendered into one or more comments, each kept under the limit.

## How large diffs are handled now

- **Split by app across comments.** Whole app sections are packed greedily; each comment carries a `part N/M` indicator and the legend appears only on the last part.
- **Truncate a single oversized app.** When one app's diff alone exceeds the budget, it's truncated by whole resources (split on the `===== group/Kind ns/name ======` boundary) with a visible notice:
  > ⚠️ Diff truncated (showing X/Y resources). Run locally to see the full diff: `argocd app diff <app> --local=<path>`
- **Reconcile on re-run.** Existing comments are found by the FQDN marker, updated in place, missing pages created, and leftovers from a larger prior run deleted — preserving the existing "don't stack comments" behavior. The marker (`<!-- argocd-diff-action <fqdn> part N/M -->`) is prefix-compatible with the old single-comment marker, so existing comments migrate cleanly.

## Notes

- **Not a breaking change.** No new inputs; `maxBuffer` is a hardcoded constant, so `action.yml`/README are untouched.
- `dist/index.js` is intentionally **not** included — `semantic-release` regenerates and commits it during release.
- **Pre-existing caveat, slightly more relevant now:** `listComments` isn't paginated (defaults to 30). On a very busy PR an older comment could fall off page 1; with multi-comment splitting this is marginally more likely. Left out of scope; possible follow-up with `octokit.paginate`.

## Testing

- New `__tests__/comment.test.ts` covers single comment, no-diffs, multi-comment split (each under the limit), single oversized app truncation, and secret scrubbing.
- `pnpm run lint` clean; `pnpm run build` bundles successfully.
- `pnpm run test`: all pass except the pre-existing `execCommand returns an err on failure` test, which hardcodes dash's "not found" wording and fails on shells where `/bin/sh` is bash — unrelated to this change.
