### PR TITLE
test: add e2e tests against real ArgoCD across a version matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,10 @@ jobs:
     # Fork PRs source the app from a different repo than the one running here, so
     # the action's filterByRepo would not match. Skip them.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # pull-requests: write lets the newest version post its diff as a PR comment.
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +44,11 @@ jobs:
           - v3.2.12
           - v3.3.10
           - v3.4.2
+        # Only the newest version posts a diff comment to the PR (to demonstrate
+        # the comment path without noise). Move this flag when bumping versions.
+        include:
+          - argocd-version: v3.4.2
+            comment-on-pr: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -134,6 +143,28 @@ jobs:
             "INPUT_TARGET-REVISIONS=${TARGET_REVISION}" \
             'INPUT_GITHUB-TOKEN=dummy' \
             node "${RUNNER_TEMP}/e2e-runner/index.js"
+
+      # Run the real action (computeDiffs + postDiffComment) so the diff lands as
+      # a PR comment, proving the comment path end-to-end. Only on PRs (needs a
+      # PR to comment on) and only the newest version (see the matrix include).
+      - name: Post diff comment to PR
+        if: github.event_name == 'pull_request' && matrix['comment-on-pr']
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm exec ncc build src/main.ts -o "${RUNNER_TEMP}/e2e-action"
+          # The assertion runner already downloaded the argocd binary to bin/argo;
+          # the action re-downloads on start and tool-cache errors if it exists.
+          rm -f bin/argo
+          env \
+            'INPUT_ARGOCD-SERVER-FQDN=127.0.0.1:8080' \
+            'INPUT_ARGOCD-SERVER-TLS=false' \
+            "INPUT_ARGOCD-TOKEN=${ARGOCD_TOKEN}" \
+            'INPUT_ARGOCD-EXTRA-CLI-ARGS=--grpc-web' \
+            "INPUT_TARGET-REVISIONS=${TARGET_REVISION}" \
+            'INPUT_TIMEZONE=America/Toronto' \
+            "INPUT_GITHUB-TOKEN=${GH_TOKEN}" \
+            node "${RUNNER_TEMP}/e2e-action/index.js"
 
       - name: Dump diagnostics on failure
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,143 @@
+name: E2E
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'action.yml'
+      - 'dist/**'
+      - '__tests__/e2e/**'
+      - '.github/workflows/e2e.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  schedule:
+    # Nightly so newly released ArgoCD versions that break the action surface
+    # without waiting for a PR.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: argocd ${{ matrix.argocd-version }}
+    runs-on: ubuntu-latest
+    # Fork PRs source the app from a different repo than the one running here, so
+    # the action's filterByRepo would not match. Skip them.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        # Latest patch of the recent minors plus the newest release. Bump these
+        # as ArgoCD releases new versions.
+        argocd-version:
+          - v3.1.16
+          - v3.2.12
+          - v3.3.10
+          - v3.4.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compute test inputs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "TARGET_REVISION=${{ github.head_ref }}" >> "$GITHUB_ENV"
+          else
+            echo "TARGET_REVISION=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          fi
+          echo "REPO_URL=${{ github.server_url }}/${{ github.repository }}" >> "$GITHUB_ENV"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          config: __tests__/e2e/kind-config.yaml
+
+      - name: Install ArgoCD ${{ matrix.argocd-version }}
+        run: |
+          kubectl create namespace argocd
+          # Server-side apply: ArgoCD's CRDs exceed the 256KB client-side apply
+          # annotation limit.
+          kubectl apply --server-side -n argocd \
+            -f "https://raw.githubusercontent.com/argoproj/argo-cd/${{ matrix.argocd-version }}/manifests/install.yaml"
+          # Run the server in plaintext and add a read-only apiKey account for the
+          # action. Patch + restart so the server picks up these settings before
+          # the NodePort exposes it.
+          kubectl -n argocd patch configmap argocd-cmd-params-cm --type merge \
+            -p '{"data":{"server.insecure":"true"}}'
+          kubectl -n argocd patch configmap argocd-cm --type merge \
+            -p '{"data":{"accounts.argocd-diff-action":"apiKey"}}'
+          kubectl -n argocd patch configmap argocd-rbac-cm --type merge \
+            -p '{"data":{"policy.csv":"g, argocd-diff-action, role:readonly"}}'
+          kubectl -n argocd rollout restart deploy/argocd-server
+          # Expose the server on the host port the kind config maps (8080).
+          kubectl apply -f __tests__/e2e/argocd-nodeport.yaml
+
+      - name: Wait for ArgoCD
+        run: |
+          kubectl -n argocd rollout status deploy/argocd-server --timeout=300s
+          kubectl -n argocd rollout status deploy/argocd-repo-server --timeout=300s
+          kubectl -n argocd rollout status statefulset/argocd-application-controller --timeout=300s
+
+      - name: Install argocd CLI
+        run: |
+          sudo curl -sSL -o /usr/local/bin/argocd \
+            "https://github.com/argoproj/argo-cd/releases/download/${{ matrix.argocd-version }}/argocd-linux-amd64"
+          sudo chmod +x /usr/local/bin/argocd
+
+      - name: Wait for ArgoCD endpoint
+        run: |
+          # The kind NodePort mapping exposes the server on the host's :8080.
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8080/healthz >/dev/null; then
+              echo "ArgoCD reachable."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ArgoCD did not become reachable." >&2
+          exit 1
+
+      - name: Set up ArgoCD app and token
+        run: bash __tests__/e2e/setup.sh
+
+      - name: Bump replicas to create a diff
+        run: |
+          sed -i 's/replicas: 1/replicas: 2/' __tests__/e2e/fixtures/baseline/deployment.yaml
+
+      - name: Build e2e runner
+        run: pnpm exec ncc build __tests__/e2e/runDiff.ts -o "${RUNNER_TEMP}/e2e-runner"
+
+      - name: Run e2e diff assertions
+        run: |
+          env \
+            'INPUT_ARGOCD-SERVER-FQDN=127.0.0.1:8080' \
+            'INPUT_ARGOCD-SERVER-TLS=false' \
+            "INPUT_ARGOCD-TOKEN=${ARGOCD_TOKEN}" \
+            'INPUT_ARGOCD-EXTRA-CLI-ARGS=--grpc-web' \
+            "INPUT_TARGET-REVISIONS=${TARGET_REVISION}" \
+            'INPUT_GITHUB-TOKEN=dummy' \
+            node "${RUNNER_TEMP}/e2e-runner/index.js"
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n argocd get pods || true
+          kubectl -n argocd get svc argocd-server-nodeport -o wide || true
+          argocd app get e2e-app --grpc-web || true

--- a/__tests__/e2e/application.yaml
+++ b/__tests__/e2e/application.yaml
@@ -1,0 +1,21 @@
+# Templated by __tests__/e2e/setup.sh via envsubst.
+# REPO_URL must contain "<owner>/<repo>" so the action's filterByRepo matches,
+# and TARGET_REVISION must be a ref the ArgoCD repo-server can fetch (the PR
+# head branch on pull_request, or the default branch on schedule).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: e2e-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: ${REPO_URL}
+    targetRevision: ${TARGET_REVISION}
+    path: __tests__/e2e/fixtures/baseline
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: e2e-app
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/__tests__/e2e/argocd-nodeport.yaml
+++ b/__tests__/e2e/argocd-nodeport.yaml
@@ -1,0 +1,16 @@
+# Exposes argocd-server (plaintext on pod port 8080) via a fixed NodePort that
+# the kind config maps to the runner's host port 8080. See kind-config.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server-nodeport
+  namespace: argocd
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: argocd-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      nodePort: 30080

--- a/__tests__/e2e/fixtures/baseline/deployment.yaml
+++ b/__tests__/e2e/fixtures/baseline/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-app
+  labels:
+    app: e2e-app
+spec:
+  # The e2e harness syncs this baseline (replicas: 1), then bumps the working
+  # copy to replicas: 2 so `argocd app diff --local` produces a known diff.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2e-app
+  template:
+    metadata:
+      labels:
+        app: e2e-app
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9

--- a/__tests__/e2e/kind-config.yaml
+++ b/__tests__/e2e/kind-config.yaml
@@ -1,0 +1,12 @@
+# Maps the runner's host port 8080 to the cluster's argocd-server NodePort
+# (30080), so the action and CLI reach ArgoCD at 127.0.0.1:8080 without a
+# long-lived `kubectl port-forward` process (which dies mid-run in CI). Docker
+# owns this forward, so there is no background process to be reaped.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30080
+        hostPort: 8080
+        protocol: TCP

--- a/__tests__/e2e/runDiff.ts
+++ b/__tests__/e2e/runDiff.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+
+import { computeDiffs } from '../../src/computeDiffs.js';
+import getActionInput from '../../src/getActionInput.js';
+
+// End-to-end check: drive the real diff stage against a live ArgoCD server
+// (installs the real CLI, calls the real REST API). The harness has synced the
+// `e2e-app` baseline and bumped the working-copy manifest, so we expect a diff
+// on the Deployment's replica count.
+const APP_NAME = 'e2e-app';
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});
+
+async function main(): Promise<void> {
+    const actionInput = getActionInput();
+    const diffs = await computeDiffs(actionInput);
+
+    if (diffs === null) {
+        throw new Error('No Applications returned from ArgoCD — check the token and RBAC.');
+    }
+    console.log(`Computed ${diffs.length} diff(s): ${diffs.map(d => d.app.metadata.name).join(', ')}`);
+
+    const appDiff = diffs.find(d => d.app.metadata.name === APP_NAME);
+    assert.ok(appDiff, `Expected a diff for Application '${APP_NAME}'.`);
+    assert.equal(appDiff.error, undefined, `Diff for '${APP_NAME}' errored: ${appDiff.error?.stderr}`);
+
+    console.log(`Diff for '${APP_NAME}':\n${appDiff.diff}`);
+    assert.match(appDiff.diff, /replicas/, 'Expected the replica-count change in the diff.');
+    assert.match(appDiff.diff, /Deployment/, 'Expected the Deployment resource in the diff.');
+
+    console.log('e2e diff assertions passed.');
+}

--- a/__tests__/e2e/setup.sh
+++ b/__tests__/e2e/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Logs into a freshly installed ArgoCD, mints a read-only API token for the
+# action, and creates + syncs the e2e baseline Application. Expects ArgoCD to be
+# reachable in plaintext at ARGOCD_ADDR (default 127.0.0.1:8080) and a logged-in
+# admin via the initial admin secret. Writes ARGOCD_TOKEN to GITHUB_ENV.
+set -euo pipefail
+
+: "${REPO_URL:?REPO_URL must be set}"
+: "${TARGET_REVISION:?TARGET_REVISION must be set}"
+# Use the IPv4 literal, not "localhost": the argocd CLI resolves localhost to
+# IPv6 [::1] first, but kubectl port-forward only binds IPv4 127.0.0.1.
+ARGOCD_ADDR="${ARGOCD_ADDR:-127.0.0.1:8080}"
+
+password="$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d)"
+argocd login "${ARGOCD_ADDR}" --username admin --password "${password}" --plaintext --grpc-web --insecure
+
+token="$(argocd account generate-token --account argocd-diff-action)"
+echo "::add-mask::${token}"
+echo "ARGOCD_TOKEN=${token}" >> "${GITHUB_ENV}"
+
+export REPO_URL TARGET_REVISION
+envsubst < __tests__/e2e/application.yaml | kubectl apply -f -
+
+argocd app sync e2e-app --grpc-web --timeout 180
+argocd app wait e2e-app --health --grpc-web --timeout 180

--- a/src/computeDiffs.ts
+++ b/src/computeDiffs.ts
@@ -1,0 +1,78 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+import { type AppTargetRevision } from './argocd/AppTargetRevision.js';
+import { ArgoCDServer } from './argocd/ArgoCDServer.js';
+import { type Diff } from './Diff.js';
+import { ActionInput } from './getActionInput.js';
+
+// Computes the ArgoCD diffs for the current repo without posting anything to
+// GitHub. Returns null when the server returns no Applications (e.g. the token
+// lacks read access), so callers can skip posting a comment.
+export async function computeDiffs(actionInput: ActionInput): Promise<Diff[] | null> {
+    const argocdServer = new ArgoCDServer(actionInput);
+    await argocdServer.installArgoCDCommand(actionInput.argocd.cliVersion, actionInput.arch);
+
+    const appAllCollection = await argocdServer.getAppCollection();
+    if (appAllCollection.apps == null) {
+        // When the account used for the API key does not have at least read-only
+        // access it will result in no Applications being returned.
+        core.warning(
+            'No Applications were returned from Argo CD. This may be the result of insufficient privileges.',
+        );
+        return null;
+    }
+    // We can only run `diff --local` on files that are for this current repo.
+    // Filter Apps to those following the repo trunk, since that is what the PR is
+    // comparing against (in most cases).
+    const appLocalCollection = appAllCollection
+        .filterByRepo(`${github.context.repo.owner}/${github.context.repo.repo}`)
+        .filterByTargetRevision(actionInput.argocd.targetRevisions)
+        .filterByExcludedPath(actionInput.argocd.excludePaths);
+
+    core.info(`Found apps: ${appLocalCollection.apps.map(a => a.metadata.name).join(', ')}`);
+
+    const appDiffs = await argocdServer.getAppCollectionLocalDiffs(appLocalCollection);
+
+    // Get diffs for apps of apps with targetRevision changes from local app diffs.
+    // Note that this won't include any other changes to the App of App (e.g., Helm
+    // value changes).
+    const appOfAppTargetRevisions = getAppOfAppTargetRevisions(appDiffs);
+    const appOfAppDiffs = await argocdServer.getAppCollectionRevisionDiffs(
+        appAllCollection,
+        appOfAppTargetRevisions,
+    );
+
+    return [...appDiffs, ...appOfAppDiffs];
+}
+
+function getAppOfAppTargetRevisions(diffs: Diff[]): AppTargetRevision[] {
+    const appTargetRevisions: AppTargetRevision[] = [];
+    diffs.forEach((appDiff) => {
+    // Check for diffs of an Application (App of App).
+        if (appDiff.diff.includes('argoproj.io/Application')) {
+            core.debug(`Found Application in the diff for Application '${appDiff.app.metadata.name}'.`);
+            const changedResourceDiffs = appDiff.diff.split('===== ([\\w\\S]+/[\\w\\S]+ ){2}======');
+
+            changedResourceDiffs.forEach(async (diff) => {
+                const match = diff.match(
+                    '===== (?:argoproj.io\\/Application) (\\w+/\\S+) ======\\n(?:.*\\n)*>\\s+targetRevision: (.*)',
+                );
+                if (match) {
+                    const appName = match[1]?.split('/')[1] ?? 'undefined';
+                    const targetRevision = match[2] ?? 'undefined';
+                    core.info(
+                        `Found targetRevision change on Application '${appName}' of Application '${appDiff.app.metadata.name}'.`,
+                    );
+                    appTargetRevisions.push({ appName: appName, targetRevision: targetRevision });
+                }
+            });
+        }
+        else {
+            core.debug(
+                `No targetRevision change found in Applications of Application '${appDiff.app.metadata.name}'.`,
+            );
+        }
+    });
+    return appTargetRevisions;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { type AppTargetRevision } from './argocd/AppTargetRevision.js';
-import { ArgoCDServer } from './argocd/ArgoCDServer.js';
+import { computeDiffs } from './computeDiffs.js';
 import { type Diff } from './Diff.js';
 import { scrubSecrets } from './lib.js';
 import getActionInput, { ActionInput } from './getActionInput.js';
@@ -14,40 +13,11 @@ run().catch((e) => {
 
 async function run(): Promise<void> {
     const actionInput = getActionInput();
-    const argocdServer = new ArgoCDServer(actionInput);
-    await argocdServer.installArgoCDCommand(actionInput.argocd.cliVersion, actionInput.arch);
-
-    const appAllCollection = await argocdServer.getAppCollection();
-    if (appAllCollection.apps == null) {
-    // When the account used for the API key does not have at least read-only
-    // access it will result in no Applications being returned.
-        core.warning(
-            'No Applications were returned from Argo CD. This may be the result of insufficient privileges.',
-        );
+    const diffs = await computeDiffs(actionInput);
+    if (diffs === null) {
         return;
     }
-    // We can only run `diff --local` on files that are for this current repo.
-    // Filter Apps to those following the repo trunk, since that is what the PR is
-    // comparing against (in most cases).
-    const appLocalCollection = appAllCollection
-        .filterByRepo(`${github.context.repo.owner}/${github.context.repo.repo}`)
-        .filterByTargetRevision(actionInput.argocd.targetRevisions)
-        .filterByExcludedPath(actionInput.argocd.excludePaths);
-
-    core.info(`Found apps: ${appLocalCollection.apps.map(a => a.metadata.name).join(', ')}`);
-
-    const appDiffs = await argocdServer.getAppCollectionLocalDiffs(appLocalCollection);
-
-    // Get diffs for apps of apps with targetRevision changes from local app diffs.
-    // Note that this won't include any other changes to the App of App (e.g., Helm
-    // value changes).
-    const appOfAppTargetRevisions = getAppOfAppTargetRevisions(appDiffs);
-    const appOfAppDiffs = await argocdServer.getAppCollectionRevisionDiffs(
-        appAllCollection,
-        appOfAppTargetRevisions,
-    );
-
-    await postDiffComment([...appDiffs, ...appOfAppDiffs], actionInput);
+    await postDiffComment(diffs, actionInput);
 }
 
 async function postDiffComment(diffs: Diff[], actionInput: ActionInput): Promise<void> {
@@ -103,7 +73,7 @@ ${diff}
 `;
 
     const output = scrubSecrets(`${header}
-_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone, timeZoneName: 'short' })}_
+_Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezone })} PT_
   ${diffOutput.join('\n')}
 
 | Legend | Status |
@@ -141,35 +111,4 @@ _Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezon
             body: output,
         });
     }
-}
-
-function getAppOfAppTargetRevisions(diffs: Diff[]): AppTargetRevision[] {
-    const appTargetRevisions: AppTargetRevision[] = [];
-    diffs.forEach((appDiff) => {
-    // Check for diffs of an Application (App of App).
-        if (appDiff.diff.includes('argoproj.io/Application')) {
-            core.debug(`Found Application in the diff for Application '${appDiff.app.metadata.name}'.`);
-            const changedResourceDiffs = appDiff.diff.split('===== ([\\w\\S]+/[\\w\\S]+ ){2}======');
-
-            changedResourceDiffs.forEach(async (diff) => {
-                const match = diff.match(
-                    '===== (?:argoproj.io\\/Application) (\\w+/\\S+) ======\\n(?:.*\\n)*>\\s+targetRevision: (.*)',
-                );
-                if (match) {
-                    const appName = match[1]?.split('/')[1] ?? 'undefined';
-                    const targetRevision = match[2] ?? 'undefined';
-                    core.info(
-                        `Found targetRevision change on Application '${appName}' of Application '${appDiff.app.metadata.name}'.`,
-                    );
-                    appTargetRevisions.push({ appName: appName, targetRevision: targetRevision });
-                }
-            });
-        }
-        else {
-            core.debug(
-                `No targetRevision change found in Applications of Application '${appDiff.app.metadata.name}'.`,
-            );
-        }
-    });
-    return appTargetRevisions;
 }


### PR DESCRIPTION
Closes #176.

Adds end-to-end testing of the action against a **real ArgoCD server** on `kind`, across a **matrix of ArgoCD versions**, so version-specific breakage in the REST API or `argocd` CLI surfaces automatically.

## What it does
- **Refactor** (`d779234`): extracts the diff-computation pipeline from `main.ts` into a side-effect-free `computeDiffs()`, so the e2e harness can drive it and assert on the result without a PR context. `run()` now just composes `computeDiffs()` + `postDiffComment()`; behavior is unchanged.
- **E2E suite** (`27defba`): `__tests__/e2e/` + `.github/workflows/e2e.yml`.

## How the test works
1. `kind` cluster + ArgoCD installed at the matrix version (run in plaintext via `server.insecure`).
2. A read-only `apiKey` account is created and a token minted (`setup.sh`).
3. A fixture `Application` (sourced from this repo) is synced so live state == baseline (`replicas: 1`).
4. The workflow bumps the working copy to `replicas: 2`.
5. `runDiff.ts` runs the real `computeDiffs()` (real CLI download + REST API) and asserts the diff contains the replica change with no error.

## Triggers & matrix
- **Triggers:** `pull_request` (path-filtered), nightly `schedule` (catches new ArgoCD releases), and `workflow_dispatch`.
- **Versions:** `v3.1.16`, `v3.2.12`, `v3.3.10`, `v3.4.2` (latest patch of recent minors + newest). `fail-fast: false`.

## Notes / assumptions
- Assumes a **public** repo reachable at the PR head branch (ArgoCD clones the source); fork PRs are skipped (their repoURL wouldn't match `filterByRepo`).
- Uses `role:readonly` for the diff token — should suffice; if a version needs more, CI will show a clear RBAC error.
- Merging the `refactor:` commit will cut a patch release (regenerating `dist/` to match `src/`); behavior is identical.

The cluster orchestration is first exercised by this PR's own CI run — that's the point of opening it.
