### PR TITLE
fix: await PR comment create/update requests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -95,7 +95,7 @@ _Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezon
 
     // Existing comments should be updated even if there are no changes this round in order to indicate that
     if (existingComment) {
-        octokit.rest.issues.updateComment({
+        await octokit.rest.issues.updateComment({
             owner,
             repo,
             comment_id: existingComment.id,
@@ -104,7 +104,7 @@ _Updated at ${new Date().toLocaleString('en-CA', { timeZone: actionInput.timezon
     // Only post a new comment when there are changes
     }
     else if (diffs.length) {
-        octokit.rest.issues.createComment({
+        await octokit.rest.issues.createComment({
             issue_number: github.context.issue.number,
             owner,
             repo,


### PR DESCRIPTION
## What

`postDiffComment` (`src/main.ts`) fired `octokit.rest.issues.createComment` and `updateComment` **without `await`**. The function returned before the GitHub API request finished.

## Why it matters

`run()` awaits `postDiffComment`, but `postDiffComment` resolved as soon as the request was *dispatched*, not completed. The process only finished the request because Node keeps the event loop alive for the pending socket — racy, and a dropped/half-sent request would silently lose the PR comment.

## Fix

`await` both the `updateComment` and `createComment` calls so the comment is confirmed before the action exits.

## Testing

`postDiffComment` is a private function in the entrypoint module (`main.ts` self-invokes `run()` on import), so it isn't unit-testable without extracting it. The E2E workflow exercises this path end-to-end (it posts a real diff comment on the newest ArgoCD version), so this PR's E2E run covers the change.