### PR TITLE
fix: make installArgoCDCommand idempotent

### DIFF
--- a/__tests__/argocd/ArgoCDServer.test.ts
+++ b/__tests__/argocd/ArgoCDServer.test.ts
@@ -21,6 +21,7 @@ const mockedExecCommand = jest.mocked(execCommand);
 
 describe('ArgoCDServer tests', function () {
     let chmodSync: sinon.SinonStub<[path: fs.PathLike, mode: fs.Mode], void>;
+    let rmSync: sinon.SinonStub<[path: fs.PathLike, options?: fs.RmOptions], void>;
 
     // rest the changes made by mockreturnvauleonce
     beforeEach(() => {
@@ -29,11 +30,13 @@ describe('ArgoCDServer tests', function () {
         mockedExecCommand.mockReset();
         // Create stub for fs.chmodSync with a return value of `void`.
         chmodSync = sinon.stub(fs, 'chmodSync');
+        rmSync = sinon.stub(fs, 'rmSync');
     });
 
     afterEach(() => {
     // Revert stub setup on chmodSync, in case other tests need it.
         chmodSync.restore();
+        rmSync.restore();
         fetchMock.clearHistory();
         fetchMock.removeRoutes();
         fetchMock.unmockGlobal();
@@ -91,6 +94,24 @@ describe('ArgoCDServer tests', function () {
             'https://github.com/argoproj/argo-cd/releases/download/v2.4.0/argocd-linux-amd64',
             'bin/argo',
         );
+    });
+
+    test('ArgoCDServer installArgoCDCommand removes a stale binary before downloading', async () => {
+        fetchMock.get('https://argocd.example/api/v1/applications', { response: { status: 200, body: '{}' } });
+
+        // mock response from fetch used in getServerVersion.
+        fetchMock.anyOnce(
+            JSON.stringify({
+                Version: 'v2.4.0+91aefab',
+            }),
+        );
+        mockedDownloadTool.mockReturnValueOnce(Promise.resolve('/path/to/tool'));
+
+        await argocdServer().installArgoCDCommand('');
+
+        // downloadTool errors if the destination already exists, so a prior
+        // binary must be cleared first.
+        expect(rmSync.calledOnceWith('bin/argo', { force: true })).toBe(true);
     });
 
     test('ArgoCDServer getAppDiff returns an error', async () => {

--- a/src/argocd/ArgoCDServer.ts
+++ b/src/argocd/ArgoCDServer.ts
@@ -1,4 +1,4 @@
-import { chmodSync } from 'fs';
+import { chmodSync, rmSync } from 'fs';
 import * as core from '@actions/core';
 import { downloadTool } from '@actions/tool-cache';
 
@@ -32,6 +32,11 @@ export class ArgoCDServer {
         if (version == '') {
             version = await this.getServerVersion();
         }
+
+        // downloadTool errors if the destination already exists, so clear any
+        // binary a previous install left behind (e.g. the action running twice
+        // in one job). force: true makes this a no-op when the file is absent.
+        rmSync(this.binaryPath, { force: true });
 
         await downloadTool(
             `https://github.com/argoproj/argo-cd/releases/download/${version}/argocd-${arch}-amd64`,


### PR DESCRIPTION
## What

`ArgoCDServer.installArgoCDCommand` downloads the `argocd` binary to a fixed path (`bin/argo`). `@actions/tool-cache`'s `downloadTool` **errors if the destination already exists**, so installing twice in the same workspace fails with:

```
Error: Destination file path bin/argo already exists
```

## Why it matters

Any consumer that runs the action twice in one job hits this. It also surfaced in the new E2E suite, where the assertion runner and the comment runner both call the action in the same workspace — the workflow currently works around it with an explicit `rm -f bin/argo`.

## Fix

`rmSync(this.binaryPath, { force: true })` before `downloadTool`. `force: true` makes it a no-op when the file is absent, so the first install is unaffected and re-installs are idempotent.

## Testing

Extended `ArgoCDServer.test.ts`: stub `fs.rmSync` and assert `installArgoCDCommand` clears `bin/argo` before downloading. All ArgoCDServer tests pass. Once this lands, the `rm -f bin/argo` workaround in `e2e.yml` can be removed (left in place here to keep this PR focused).