### PR TITLE
ci(dependabot): add cooldown to delay new dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
+      semver-minor-days: 5
+      semver-major-days: 14
     groups:
       actions-minor:
         update-types:
@@ -13,6 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
+      semver-minor-days: 5
+      semver-major-days: 14
     ignore:
       - dependency-name: "@types/node"
         update-types:


### PR DESCRIPTION
## What

Adds a `cooldown` block to both ecosystems (`github-actions` and `npm`) in `.github/dependabot.yml`:

- `default-days: 2`
- `semver-minor-days: 5`
- `semver-major-days: 14`

## Why

Dependabot was opening PRs against just-published releases (e.g. #216), whose ecosystem hadn't caught up yet, breaking CI before upstream fixes landed. The cooldown holds updates back until the release has aged, giving the ecosystem time to stabilize.

## Notes

- Cooldown granularity is **days** (Dependabot has no hour-level setting); age is measured from the release publish date.
- This does not retroactively affect already-open PRs like #216 — close and let Dependabot re-open after the cooldown, or wait out the upstream fix.