### PR TITLE
ci(e2e): pin deterministic admin password to fix login race

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,15 +85,26 @@ jobs:
           # annotation limit.
           kubectl apply --server-side -n argocd \
             -f "https://raw.githubusercontent.com/argoproj/argo-cd/${{ matrix.argocd-version }}/manifests/install.yaml"
-          # Run the server in plaintext and add a read-only apiKey account for the
-          # action. Patch + restart so the server picks up these settings before
-          # the NodePort exposes it.
+          # Let the first server generation finish bootstrapping before we touch
+          # the admin credential. Otherwise it races our admin.password patch
+          # below (and previously raced the auto-generated
+          # argocd-initial-admin-secret), leaving the active hash out of sync and
+          # login failing intermittently on whichever matrix leg starts fastest.
+          kubectl -n argocd rollout status deploy/argocd-server --timeout=300s
+          # Run the server in plaintext, add a read-only apiKey account for the
+          # action, and pin a deterministic admin password (throwaway test creds).
+          # Patch + restart so the server picks up these settings before the
+          # NodePort exposes it.
           kubectl -n argocd patch configmap argocd-cmd-params-cm --type merge \
             -p '{"data":{"server.insecure":"true"}}'
           kubectl -n argocd patch configmap argocd-cm --type merge \
             -p '{"data":{"accounts.argocd-diff-action":"apiKey"}}'
           kubectl -n argocd patch configmap argocd-rbac-cm --type merge \
             -p '{"data":{"policy.csv":"g, argocd-diff-action, role:readonly"}}'
+          # bcrypt(cost 10) of "argocd-admin-pw"; setup.sh logs in with that
+          # plaintext. Keep the two in sync if either changes.
+          kubectl -n argocd patch secret argocd-secret --type merge \
+            -p '{"stringData":{"admin.password":"$2a$10$NwZRsmGbF1LhBdyHB7GYbuH9Ax.M8SilWZ8joUC3xqC5zDWCyuBW2","admin.passwordMtime":"2024-01-01T00:00:00Z"}}'
           kubectl -n argocd rollout restart deploy/argocd-server
           # Expose the server on the host port the kind config maps (8080).
           kubectl apply -f __tests__/e2e/argocd-nodeport.yaml

--- a/__tests__/e2e/setup.sh
+++ b/__tests__/e2e/setup.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Logs into a freshly installed ArgoCD, mints a read-only API token for the
 # action, and creates + syncs the e2e baseline Application. Expects ArgoCD to be
-# reachable in plaintext at ARGOCD_ADDR (default 127.0.0.1:8080) and a logged-in
-# admin via the initial admin secret. Writes ARGOCD_TOKEN to GITHUB_ENV.
+# reachable in plaintext at ARGOCD_ADDR (default 127.0.0.1:8080) and the
+# deterministic admin password the e2e workflow pins on argocd-secret. Writes
+# ARGOCD_TOKEN to GITHUB_ENV.
 set -euo pipefail
 
 : "${REPO_URL:?REPO_URL must be set}"
@@ -11,8 +12,9 @@ set -euo pipefail
 # IPv6 [::1] first, but kubectl port-forward only binds IPv4 127.0.0.1.
 ARGOCD_ADDR="${ARGOCD_ADDR:-127.0.0.1:8080}"
 
-password="$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d)"
-argocd login "${ARGOCD_ADDR}" --username admin --password "${password}" --plaintext --grpc-web --insecure
+# Deterministic throwaway admin password pinned by the e2e workflow's
+# argocd-secret patch; keep in sync with the bcrypt hash there.
+argocd login "${ARGOCD_ADDR}" --username admin --password 'argocd-admin-pw' --plaintext --grpc-web --insecure
 
 token="$(argocd account generate-token --account argocd-diff-action)"
 echo "::add-mask::${token}"


### PR DESCRIPTION
## What

The nightly E2E run #26 failed on the **v3.2.12** matrix leg at the `argocd login` step in `setup.sh`:

```
rpc error: code = Unauthenticated desc = Invalid username or password
```

The other three legs passed. v3.2.12 was the fastest job (1m15s), which is the tell.

## Root cause

The install step issued `kubectl rollout restart deploy/argocd-server` ~1s after applying the empty `argocd-secret`. That put two server generations in play against a secret with no `admin.password`, so both could bootstrap the admin credential. ArgoCD writes the plaintext to `argocd-initial-admin-secret` (create-if-absent) and the bcrypt hash to `argocd-secret.admin.password` as separate writes — when two generations race, the plaintext `setup.sh` reads drifts from the active hash and login is rejected. It surfaces on whichever leg's pods schedule fastest, which is why it looked version-specific and reproduced across reruns.

## Fix

- Wait for the first `argocd-server` rollout to finish bootstrapping **before** patching credentials.
- Patch a deterministic throwaway admin password (`argocd-admin-pw`, bcrypt cost 10) onto `argocd-secret` before the restart. The pre-restart pod no longer regenerates (the field is set), and the restarted pod loads the pinned value.
- `setup.sh` logs in with the fixed password instead of reading the race-prone `argocd-initial-admin-secret`.

These are throwaway test credentials on an ephemeral kind cluster — not a secret.

## Verification

- `bash -n setup.sh` passes; workflow YAML parses.
- bcrypt hash verified against the plaintext via `htpasswd`.
- No remaining references to `argocd-initial-admin-secret`.
- Real proof is this PR's E2E run going green across all four matrix legs.