### PR TITLE
ci: modernize workflow action usage

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - uses: ahmadnassri/action-dependabot-auto-merge@v2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - uses: codelytv/pr-size-labeler@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/update-argocd-versions.yml
+++ b/.github/workflows/update-argocd-versions.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
 
       - name: Open pull request
         if: steps.resolve.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: chore/bump-argocd-e2e-versions


### PR DESCRIPTION
## What

Action-version hygiene across all workflows, plus clearing the two deprecation warnings seen in the bump-workflow run.

- **`peter-evans/create-pull-request` v7 → v8** — v8 runs on Node 24, clearing the *"Node.js 20 actions are deprecated"* warning.
- **`create-github-app-token`: `app-id` → `client-id`** in all four usages (release, dependabot-auto-merge, labeler, update-argocd-versions), referencing the new `vars.RELEASE_BOT_CLIENT_ID` variable. Clears the *"Input 'app-id' has been deprecated, use 'client-id' instead"* warning and follows the action's documented approach.

## Version audit

Checked every action against its latest release; all others were already pinned to their latest major (floating to newest minor/patch):

| Action | Pin | Latest |
|---|---|---|
| actions/checkout | v6 | v6.0.3 |
| actions/setup-node | v6 | v6.4.0 |
| actions/create-github-app-token | v3 | v3.2.0 |
| ArtiomTr/jest-coverage-report-action | v2 | v2.3.1 |
| ahmadnassri/action-dependabot-auto-merge | v2 | v2.6.6 |
| helm/kind-action | v1 | v1.14.0 |
| codelytv/pr-size-labeler | v1 | v1.10.4 |
| amannn/action-semantic-pull-request | v6 | v6.1.1 |
| mdvorak/update-action-readme | v1 | v1.2.0 |
| cycjimmy/semantic-release-action | v6 | v6.0.0 |
| peter-evans/create-pull-request | v7 → **v8** | v8.1.1 |

## Note

The `RELEASE_BOT_APP_ID` repository variable is now unused and can be removed once this merges. `RELEASE_BOT_APP_PRIVATE_KEY` is still required.